### PR TITLE
Introduce Mailcatcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'mailcatcher'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,53 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (4.2.5.1)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    daemons (1.2.3)
+    eventmachine (1.0.9.1)
+    i18n (0.7.0)
+    json (1.8.3)
+    mail (2.6.3)
+      mime-types (>= 1.16, < 3)
+    mailcatcher (0.6.3)
+      activesupport (>= 4.0.0, < 5)
+      eventmachine (= 1.0.9.1)
+      mail (~> 2.3)
+      sinatra (~> 1.2)
+      skinny (~> 0.2.3)
+      sqlite3 (~> 1.3)
+      thin (~> 1.5.0)
+    mime-types (2.99)
+    minitest (5.8.4)
+    rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    skinny (0.2.4)
+      eventmachine (~> 1.0.0)
+      thin (>= 1.5, < 1.7)
+    sqlite3 (1.3.11)
+    thin (1.5.1)
+      daemons (>= 1.0.9)
+      eventmachine (>= 0.12.6)
+      rack (>= 1.0.0)
+    thread_safe (0.3.5)
+    tilt (2.0.2)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mailcatcher
+
+BUNDLED WITH
+   1.11.2

--- a/config/config.exs
+++ b/config/config.exs
@@ -19,6 +19,15 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
+config :meli, :smtp,
+  relay: "127.0.0.1",
+  username: "",
+  password: "",
+  port: 1025,
+  ssl: false,
+  auth: :never,
+  tls: :never
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"

--- a/lib/meli/mail_worker.ex
+++ b/lib/meli/mail_worker.ex
@@ -29,13 +29,6 @@ defmodule Meli.MailWorker do
   end
 
   defp smtp_config do
-    case Mix.env do
-      :prod  -> smtp_prod_config
-      _other -> smtp_test_config
-    end
-  end
-
-  defp smtp_prod_config do
     config = Application.get_env(:meli, :smtp)
 
     %Mailman.SmtpConfig{
@@ -43,12 +36,9 @@ defmodule Meli.MailWorker do
       username: config[:username],
       password: config[:password],
       port:     config[:port],
-      ssl: true,
-      auth: :always
+      ssl:      config[:ssl],
+      auth:     config[:auth],
+      tls:      config[:tls]
     }
-  end
-
-  defp smtp_test_config do
-    %Mailman.TestConfig{store_deliveries: true}
   end
 end


### PR DESCRIPTION
The integration testing is so difficult because Meli is mail delivery system which may affect the outside world. In such case, [mailcatcher](http://mailcatcher.me/) is useful.

It boots up a SMTP server listening on port 1025. You can see how it works with following commands.

```
bundle install
bundle exec mailcatcher
mix phoenix.server

# open another terminal
curl -X POST -H "Content-Type: application/json" -d '{"mail": {"subject": "Hello", "from": "goflb.jh@gmail.com", "to": ["goflb.jh@gmail.com"], "text": "Hello my friend!"}}' http://localhost:4000/api/mail

open http://localhost:1080
```
